### PR TITLE
Add Blender 2.80 support in plugin

### DIFF
--- a/addons/io_sketchfab_plugin/__init__.py
+++ b/addons/io_sketchfab_plugin/__init__.py
@@ -33,16 +33,20 @@ from bpy.props import (StringProperty,
                        BoolProperty,
                        IntProperty,
                        PointerProperty)
+
 from .io import *
-from .blender.imp.gltf2_blender_gltf import *
 from .sketchfab import Config, Utils, Cache
+from .blender.imp.gltf2_blender_gltf import *
+
+from .blender.blender_version import Version
+
 
 # Blender 2.79 has been shipped with openssl version 0.9.8 which uses a TLS protocol
 # that is now blocked for security reasons on websites (github.com for example)
 # In order to allow communication with github.com and other websites, the code will intend
 # to use the updated openssl version distributed with the addon.
 # Note: Blender 2.8 will have a more recent openssl version. This fix is only for 2.79 and olders
-if bpy.app.version[1] < 80 and not bpy.app.build_platform == b'Windows':
+if bpy.app.version < (2, 80, 0) and not bpy.app.build_platform == b'Windows':
     try:
         sslib_path = None
         if bpy.app.build_platform == b'Darwin':
@@ -67,6 +71,7 @@ if bpy.app.version[1] < 80 and not bpy.app.build_platform == b'Windows':
         print(e)
         print("Failed to override SSL lib. The plugin will not be able to check for updates")
 
+
 bl_info = {
     'name': 'Sketchfab Plugin',
     'description': 'Browse and download free Sketchfab downloadable models',
@@ -74,7 +79,7 @@ bl_info = {
     'license': 'GPL',
     'deps': '',
     'version': (1, 1, 0),
-    'blender': (2, 7, 9),
+    "blender": (2, 80, 0),
     'location': 'View3D > Tools > Sketchfab',
     'warning': '',
     'wiki_url': 'https://github.com/sketchfab/blender-plugin/releases',
@@ -82,7 +87,15 @@ bl_info = {
     'link': 'https://github.com/sketchfab/blender-plugin',
     'support': 'COMMUNITY',
     'category': 'Import-Export'
-    }
+}
+bl_info['blender'] = getattr(bpy.app, "version")
+
+"""
+if bpy.app.version < (2, 80, 0):
+    bl_info["blender"] = (2, 79, 0)
+elif bpy.app.version == (2, 80, 0):
+    bl_info["blender"] = (2, 80, 0)
+"""
 
 PLUGIN_VERSION = str(bl_info['version']).strip('() ').replace(',', '.')
 preview_collection = {}
@@ -344,28 +357,36 @@ class SketchfabLoginProps(bpy.types.PropertyGroup):
                 set_login_status('ERROR', 'Password is empty')
             bpy.ops.wm.sketchfab_login('EXEC_DEFAULT')
 
-    email = StringProperty(
-            name="email",
-            description="User email",
-            default="")
+    """
+    Version.assign_property(self, "email", StringProperty, name="email",
+    description="User email",
+    default="")
+    """
 
-    password = StringProperty(
-            name="password",
-            description="User password",
-            subtype='PASSWORD',
-            default="",
-            update=update_tr
-            )
+    vars()["email"] = StringProperty(
+        name="email",
+        description="User email",
+        default=""
+    )
 
-    access_token = StringProperty(
+
+    vars()["password"] = StringProperty(
+        name="password",
+        description="User password",
+        subtype='PASSWORD',
+        default="",
+        update=update_tr
+    )
+
+    vars()["access_token"] = StringProperty(
             name="access_token",
             description="oauth access token",
             subtype='PASSWORD',
             default=""
             )
 
-    status = StringProperty(name='', default='')
-    status_type = EnumProperty(
+    vars()["status"] = StringProperty(name='', default='')
+    vars()["status_type"] = EnumProperty(
             name="Login status type",
             items=(('ERROR', "Error", ""),
                        ('INFO', "Information", ""),
@@ -374,15 +395,15 @@ class SketchfabLoginProps(bpy.types.PropertyGroup):
             default='FILE_REFRESH'
             )
 
-    last_username = StringProperty(default="default")
-    last_password = StringProperty(default="default")
+    vars()["last_username"] = StringProperty(default="default")
+    vars()["last_password"] = StringProperty(default="default")
 
     skfb_api = SketchfabApi()
 
 
 class SketchfabBrowserPropsProxy(bpy.types.PropertyGroup):
     # Search
-    query = StringProperty(
+    vars()["query"] = StringProperty(
             name="",
             update=refresh_search,
             description="Query to search",
@@ -390,21 +411,21 @@ class SketchfabBrowserPropsProxy(bpy.types.PropertyGroup):
             options={'SKIP_SAVE'}
             )
 
-    pbr = BoolProperty(
+    vars()["pbr"] = BoolProperty(
             name="PBR",
             description="Search for PBR model only",
             default=False,
             update=refresh_search,
             )
 
-    categories = EnumProperty(
+    vars()["categories"] = EnumProperty(
             name="Categories",
             items=Config.SKETCHFAB_CATEGORIES,
             description="Show only models of category",
             default='ALL',
             update=refresh_search
             )
-    face_count = EnumProperty(
+    vars()["face_count"] = EnumProperty(
             name="Face Count",
             items=Config.SKETCHFAB_FACECOUNT,
             description="Determines which meshes are exported",
@@ -412,7 +433,7 @@ class SketchfabBrowserPropsProxy(bpy.types.PropertyGroup):
             update=refresh_search
             )
 
-    sort_by = EnumProperty(
+    vars()["sort_by"] = EnumProperty(
             name="Sort by",
             items=Config.SKETCHFAB_SORT_BY,
             description="Sort ",
@@ -420,28 +441,28 @@ class SketchfabBrowserPropsProxy(bpy.types.PropertyGroup):
             update=refresh_search
             )
 
-    animated = BoolProperty(
+    vars()["animated"] = BoolProperty(
             name="Animated",
             description="Show only models with animation",
             default=False,
             update=refresh_search
             )
 
-    staffpick = BoolProperty(
+    vars()["staffpick"] = BoolProperty(
             name="Staffpick",
             description="Show only staffpick models",
             default=False,
             update=refresh_search
             )
 
-    own_models = BoolProperty(
+    vars()["own_models"] = BoolProperty(
             name="My models (PRO)",
             description="Browse your own models (full library is only available for PRO account)",
             default=False,
             update=refresh_search
         )
 
-    is_refreshing = BoolProperty(
+    vars()["is_refreshing"] = BoolProperty(
         name="Refresh",
         description="Refresh",
         default=False,
@@ -449,79 +470,79 @@ class SketchfabBrowserPropsProxy(bpy.types.PropertyGroup):
 
 class SketchfabBrowserProps(bpy.types.PropertyGroup):
     # Search
-    query = StringProperty(
+    vars()["query"] = StringProperty(
             name="Search",
             description="Query to search",
             default=""
             )
 
-    pbr = BoolProperty(
+    vars()["pbr"] = BoolProperty(
             name="PBR",
             description="Search for PBR model only",
             default=False
             )
 
-    categories = EnumProperty(
+    vars()["categories"] = EnumProperty(
             name="Categories",
             items=Config.SKETCHFAB_CATEGORIES,
             description="Show only models of category",
             default='ALL',
              )
 
-    face_count = EnumProperty(
+    vars()["face_count"] = EnumProperty(
             name="Face Count",
             items=Config.SKETCHFAB_FACECOUNT,
             description="Determines which meshes are exported",
             default='ANY',
             )
 
-    sort_by = EnumProperty(
+    vars()["sort_by"] = EnumProperty(
             name="Sort by",
             items=Config.SKETCHFAB_SORT_BY,
             description="Sort ",
             default='LIKES',
             )
 
-    animated = BoolProperty(
+    vars()["animated"] = BoolProperty(
             name="Animated",
             description="Show only models with animation",
             default=False,
             )
 
-    staffpick = BoolProperty(
+    vars()["staffpick"] = BoolProperty(
             name="Staffpick",
             description="Show only staffpick models",
             default=False,
             )
 
-    own_models = BoolProperty(
+    vars()["own_models"] = BoolProperty(
             name="My models (PRO)",
             description="Search within my models",
             default=False,
             update=refresh_search
         )
 
-    status = StringProperty(name='status', default='idle')
+    vars()["status"] = StringProperty(name='status', default='idle')
 
-    use_preview = BoolProperty(
+    vars()["use_preview"] = BoolProperty(
         name="Use Preview",
         description="Show results using preview widget instead of regular buttons with thumbnails as icons",
         default=True
         )
 
     search_results = {}
-    current_key = StringProperty(name='current', default='current')
-    has_searched_next = BoolProperty(name='next', default=False)
-    has_searched_prev = BoolProperty(name='prev', default=False)
+    vars()["current_key"] = StringProperty(name='current', default='current')
+    vars()["has_searched_next"] = BoolProperty(name='next', default=False)
+    vars()["has_searched_prev"] = BoolProperty(name='prev', default=False)
 
     skfb_api = SketchfabLoginProps.skfb_api
     custom_icons = bpy.utils.previews.new()
-    has_loaded_thumbnails = BoolProperty(default=False)
+    vars()["has_loaded_thumbnails"] = BoolProperty(default=False)
 
-    is_latest_version = IntProperty(default=-1)
+    vars()["is_latest_version"] = IntProperty(default=-1)
 
-    import_status = StringProperty(name='import', default='')
-    is_plugin_enabled = BoolProperty(default=False)
+    vars()["import_status"] = StringProperty(name='import', default='')
+    vars()["is_plugin_enabled"] = BoolProperty(default=False)
 
 
 def list_current_results(self, context):
@@ -570,8 +591,8 @@ def draw_search(layout, context):
 
     ro.operator("wm.sketchfab_search", text="Search", icon='VIEWZOOM')
     if props.own_models and skfb_api.is_user_logged() and not skfb_api.is_user_pro():
-        layout.label('A PRO account is required to gain full API access', icon='QUESTION')
-        layout.label('      to your personal library')
+        layout.label(text='A PRO account is required to gain full API access', icon='QUESTION')
+        layout.label(text='      to your personal library')
 
     pprops = get_sketchfab_props()
 
@@ -579,20 +600,20 @@ def draw_search(layout, context):
 def draw_model_info(layout, model, context):
     ui_model_props = layout.box().column(align=True)
     ui_model_props.operator("wm.sketchfab_view", text="View on Sketchfab", icon='WORLD').model_uid = model.uid
-    ui_model_props.label('{}'.format(model.title), icon='OBJECT_DATA')
-    ui_model_props.label('{}'.format(model.author), icon='ARMATURE_DATA')
+    ui_model_props.label(text='{}'.format(model.title), icon='OBJECT_DATA')
+    ui_model_props.label(text='{}'.format(model.author), icon='ARMATURE_DATA')
 
     if model.license:
-        ui_model_props.label('{}'.format(model.license), icon='TEXT')
+        ui_model_props.label(text='{}'.format(model.license), icon='TEXT')
     else:
-        ui_model_props.label('Fetching..')
+        ui_model_props.label(text='Fetching..')
 
     if model.vertex_count and model.face_count:
         ui_model_stats = ui_model_props.row()
-        ui_model_stats.label('Verts: {}  |  Faces: {}'.format(Utils.humanify_number(model.vertex_count), Utils.humanify_number(model.face_count)), icon='MESH_DATA')
+        ui_model_stats.label(text='Verts: {}  |  Faces: {}'.format(Utils.humanify_number(model.vertex_count), Utils.humanify_number(model.face_count)), icon='MESH_DATA')
 
     if(model.animated):
-        ui_model_props.label('Animated: ' + model.animated, icon='ANIM_DATA')
+        ui_model_props.label(text='Animated: ' + model.animated, icon='ANIM_DATA')
 
     import_ops = ui_model_props.column()
     skfb = get_sketchfab_props()
@@ -608,7 +629,7 @@ def draw_model_info(layout, model, context):
         downloadlabel = skfb.import_status
 
     download_icon = 'EXPORT' if import_ops.enabled else 'INFO'
-    import_ops.label('')
+    import_ops.label(text='')
     import_ops.operator("wm.sketchfab_download", icon=download_icon, text=downloadlabel, translate=False, emboss=True).model_uid = model.uid
 
 
@@ -743,7 +764,10 @@ class ThumbnailCollector(threading.Thread):
     def handle_thumbnail(self, r, *args, **kwargs):
         uid = r.url.split('/')[4]
         if not os.path.exists(Config.SKETCHFAB_THUMB_DIR):
-            os.makedirs(Config.SKETCHFAB_THUMB_DIR)
+            try:
+                os.makedirs(Config.SKETCHFAB_THUMB_DIR)
+            except:
+                pass
         thumbnail_path = os.path.join(Config.SKETCHFAB_THUMB_DIR, uid) + '.jpeg'
 
         with open(thumbnail_path, "wb") as f:
@@ -835,7 +859,7 @@ class ImportModalOperator(bpy.types.Operator):
         return {'FINISHED'}
 
     def modal(self, context, event):
-        bpy.context.scene.render.engine = 'CYCLES'
+        bpy.context.scene.render.engine = Version.ENGINE
         gltf_importer = glTFImporter(self.gltf_path, Log.default())
         success, txt = gltf_importer.read()
         if not success:
@@ -874,8 +898,8 @@ class View3DPanel:
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'TOOLS'
     bl_label = "Sketchfab Assets Browser"
-    bl_category = "Sketchfab"
     bl_context = 'objectmode'
+    bl_category = "Sketchfab" if bpy.app.version == (2, 79, 0) else ""
 
     @classmethod
     def poll(cls, context):
@@ -900,12 +924,12 @@ class LoginPanel(View3DPanel, bpy.types.Panel):
             layout.enabled = get_plugin_enabled()
             if skfb_login.skfb_api.is_user_logged():
                 login_row = layout.row()
-                login_row.label('Logged in as {}'.format(skfb_login.skfb_api.get_user_info()))
-                login_row.operator('wm.sketchfab_login', text='Logout', icon='GO_LEFT').authenticate = False
+                login_row.label(text='Logged in as {}'.format(skfb_login.skfb_api.get_user_info()))
+                login_row.operator('wm.sketchfab_login', text='Logout', icon='DISCLOSURE_TRI_RIGHT').authenticate = False
                 if skfb_login.status:
                     layout.prop(skfb_login, 'status', icon=skfb_login.status_type)
             else:
-                layout.label("Login to your Sketchfab account", icon='INFO')
+                layout.label(text="Login to your Sketchfab account", icon='INFO')
                 layout.prop(skfb_login, "email")
                 layout.prop(skfb_login, "password")
                 ops_row = layout.row()
@@ -928,7 +952,7 @@ class LoginPanel(View3DPanel, bpy.types.Panel):
         doc_ui = self.layout.row()
         doc_ui.operator('wm.skfb_help', text='Documentation', icon='QUESTION')
         doc_ui.operator('wm.skfb_report_issue', text='Report an issue', icon='ERROR')
-        self.layout.label(Config.SKETCHFAB_TEMP_DIR, icon="SCRIPT")
+        self.layout.label(text=Config.SKETCHFAB_TEMP_DIR, icon="SCRIPT")
 
         layout = self.layout
 
@@ -951,11 +975,11 @@ class FiltersPanel(View3DPanel, bpy.types.Panel):
         col.separator()
         col.prop(props, "categories")
 
-        col.label('Sort by')
+        col.label(text='Sort by')
         sb = col.row()
         sb.prop(props, "sort_by", expand=True)
 
-        col.label('Face count')
+        col.label(text='Face count')
         col.prop(props, "face_count", expand=True)
 
 
@@ -982,7 +1006,7 @@ def draw_results_icons(results, props, nbcol=4):
                     col2.operator("wm.sketchfab_modelview", text="{}".format(model.title + ' by ' + model.author)).uid = list(current.keys())[index]
     else:
         results.row()
-        results.row().label('No results')
+        results.row().label(text='No results')
         results.row()
 
 
@@ -1010,7 +1034,7 @@ class ResultsPanel(View3DPanel, bpy.types.Panel):
 
         result_label = 'Click below to see more results'
 
-        col.label(result_label, icon='INFO')
+        col.label(text=result_label, icon='INFO')
         try:
             col.template_icon_view(bpy.context.window_manager, 'result_previews', show_labels=True, scale=5.0)
         except Exception:
@@ -1063,7 +1087,7 @@ class SketchfabLogger(bpy.types.Operator):
 
 # Operator to perform search on Sketchfab
 class SketchfabBrowse(View3DPanel, bpy.types.Panel):
-    bl_idname = "wm.sketchfab_browse"
+    bl_idname = "wm.sketchfab_browse" if bpy.app.version == (2, 79, 0) else "VIEW3D_PT_sketchfab_browse"
     bl_label = "Search"
 
     def draw(self, context):

--- a/addons/io_sketchfab_plugin/blender/blender_version.py
+++ b/addons/io_sketchfab_plugin/blender/blender_version.py
@@ -1,0 +1,61 @@
+import bpy
+
+class Version:
+    """Adjusts functions according to the differences between 2.79 and 2.8"""
+
+    #Render engine
+    ENGINE = "CYCLES" if bpy.app.version < (2, 80, 0) else "BLENDER_EEVEE"
+
+    # Selection / Deselection
+    def select(obj):
+        if bpy.app.version < (2, 80, 0):
+            obj.select = True
+        else:
+            obj.select_set(True)
+    def deselect(obj):
+        if bpy.app.version < (2, 80, 0):
+            obj.select = False
+        else:
+            obj.select_set(False)
+
+    # Object linking
+    def link(scene, obj):
+        if bpy.app.version < (2, 80, 0):
+            bpy.data.scenes[scene].objects.link(obj)
+        else:
+            bpy.data.scenes[scene].collection.objects.link(obj)
+
+    # Active object
+    def get_active_object():
+        if bpy.app.version < (2, 80, 0):
+            return bpy.context.scene.objects.active
+        else:
+            return bpy.context.view_layer.objects.active
+    def set_active_object(obj):
+        if bpy.app.version < (2, 80, 0):
+            bpy.context.scene.objects.active = obj
+            #self.select(obj)
+        else:
+            bpy.context.view_layer.objects.active = obj
+
+    # Matrix multiplication
+    def mat_mult(A, B):
+        if bpy.app.version < (2, 80, 0):
+            return A * B
+        else:
+            return A @ B
+
+    # Setting colorspace
+    def set_colorspace(texture):
+        if bpy.app.version < (2, 80, 0):
+            texture.color_space = 'NONE'
+        else:
+            if texture.image:
+                texture.image.colorspace_settings.is_data = True
+
+    # Setting the active scene
+    def set_scene(scene):
+        if bpy.app.version < (2, 80, 0):
+            bpy.context.screen.scene = scene
+        else:
+            bpy.context.window.scene = scene

--- a/addons/io_sketchfab_plugin/blender/com/gltf2_blender_material_helpers.py
+++ b/addons/io_sketchfab_plugin/blender/com/gltf2_blender_material_helpers.py
@@ -40,6 +40,10 @@ def get_diffuse_texture(node_tree):
 
     return None
 
+def get_preoutput_node(node_tree):
+    output_node = get_output_node(node_tree)
+    return output_node.inputs['Surface'].links[0].from_node
+
 def get_preoutput_node_output(node_tree):
     output_node = get_output_node(node_tree)
     preoutput_node = output_node.inputs['Surface'].links[0].from_node

--- a/addons/io_sketchfab_plugin/blender/exp/gltf2_blender_generate.py
+++ b/addons/io_sketchfab_plugin/blender/exp/gltf2_blender_generate.py
@@ -31,6 +31,9 @@ from ..com.gltf2_blender_image_util import *
 from io_scene_gltf2.blender.com import gltf2_blender_json
 from io_scene_gltf2.io.com import gltf2_io
 
+# Version management
+from ...blender.blender_version import Version
+
 #
 # Functions
 #
@@ -876,7 +879,7 @@ def bake_action(export_settings, blender_object, blender_action):
 
     #
 
-    bpy.context.scene.objects.active = blender_object
+    Version.set_active_object(blender_object)
     blender_object.animation_data.action = blender_action
 
     #
@@ -1842,7 +1845,7 @@ def generate_nodes(operator,
                 if blender_object.animation_data is not None:
                     temp_action = blender_object.animation_data.action
 
-                bpy.context.scene.objects.active = blender_object
+                Version.set_active_object(blender_object)
                 bpy.ops.object.mode_set(mode='POSE')
                 bpy.ops.nla.bake(frame_start=bpy.context.scene.frame_current, frame_end=bpy.context.scene.frame_current,
                                  only_selected=False, visual_keying=True, clear_constraints=False,

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_KHR_materials_pbrSpecularGlossiness.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_KHR_materials_pbrSpecularGlossiness.py
@@ -23,13 +23,16 @@
 import bpy
 from .gltf2_blender_texture import *
 
+# Version management
+from ..blender_version import Version
+
 class BlenderKHR_materials_pbrSpecularGlossiness():
 
 
     @staticmethod
     def create(gltf, pbrSG, mat_name, vertex_color):
         engine = bpy.context.scene.render.engine
-        if engine == 'CYCLES':
+        if engine == Version.ENGINE:
             BlenderKHR_materials_pbrSpecularGlossiness.create_cycles(gltf, pbrSG, mat_name, vertex_color)
         else:
             pass #TODO for internal / Eevee in future 2.8
@@ -261,7 +264,8 @@ class BlenderKHR_materials_pbrSpecularGlossiness():
             BlenderTextureInfo.create(gltf, pbrSG['specularGlossinessTexture']['index'])
             spec_text = node_tree.nodes.new('ShaderNodeTexImage')
             spec_text.image = bpy.data.images[gltf.data.images[gltf.data.textures[pbrSG['specularGlossinessTexture']['index']].source].blender_image_name]
-            spec_text.color_space = 'NONE'
+
+            Version.set_colorspace(spec_text)
             spec_text.location = -500,0
 
             spec_mapping = node_tree.nodes.new('ShaderNodeMapping')
@@ -287,7 +291,7 @@ class BlenderKHR_materials_pbrSpecularGlossiness():
 
             spec_text = node_tree.nodes.new('ShaderNodeTexImage')
             spec_text.image = bpy.data.images[gltf.data.images[gltf.data.textures[pbrSG['specularGlossinessTexture']['index']].source].blender_image_name]
-            spec_text.color_space = 'NONE'
+            Version.set_colorspace(spec_text)
             spec_text.location = -1000,0
 
             spec_math     = node_tree.nodes.new('ShaderNodeMath')

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_KHR_materials_pbrSpecularGlossiness.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_KHR_materials_pbrSpecularGlossiness.py
@@ -235,14 +235,14 @@ class BlenderKHR_materials_pbrSpecularGlossiness():
 
                 node_tree.links.new(separate.inputs[0], text_node.outputs[0])
 
-                node_tree.links.new(principled.inputs[0], combine.outputs[0])
-
                 node_tree.links.new(math_vc_R.inputs[0], separate.outputs[0])
                 node_tree.links.new(math_vc_G.inputs[0], separate.outputs[1])
                 node_tree.links.new(math_vc_B.inputs[0], separate.outputs[2])
 
             else:
-                node_tree.links.new(diffuse.inputs[0], text_node.outputs[0])
+                pass
+
+            node_tree.links.new(diffuse.inputs[0], text_node.outputs[0])
 
             # Common for both mode (non vertex color / vertex color)
 

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_camera.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_camera.py
@@ -22,6 +22,9 @@
 
 import bpy
 
+# Version management
+from ..blender_version import Version
+
 class BlenderCamera():
 
     @staticmethod
@@ -47,5 +50,10 @@ class BlenderCamera():
 
 
         obj = bpy.data.objects.new(pycamera.name, cam)
-        bpy.data.scenes[gltf.blender_scene].objects.link(obj)
+
+        if bpy.app.version == (2, 79, 0):
+            Version.link(gltf.blender_scene, obj)
+        else:
+            bpy.context.scene.collection.children[-1].objects.link(obj)
+
         return obj

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_gltf.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_gltf.py
@@ -24,6 +24,9 @@ import bpy
 from .gltf2_blender_scene import *
 from ...io.com.gltf2_io_trs import *
 
+# Version management
+from ..blender_version import Version
+
 class BlenderGlTF():
 
     @staticmethod
@@ -35,7 +38,7 @@ class BlenderGlTF():
 
         # Keep selection and active object
         selected_objects = bpy.context.selected_objects
-        active_object = bpy.context.scene.objects.active
+        active_object    = Version.get_active_object()
 
         # Armature correction
         # Try to detect bone chains, and set bone lengths
@@ -49,7 +52,7 @@ class BlenderGlTF():
 
         threshold = 0.001
         for armobj in [obj for obj in bpy.data.objects if obj.type == "ARMATURE"]:
-            bpy.context.scene.objects.active = armobj
+            Version.set_active_object(armobj)
             armature = armobj.data
             bpy.ops.object.mode_set(mode="EDIT")
             for bone in armature.edit_bones:
@@ -79,13 +82,8 @@ class BlenderGlTF():
 
 
         # Restore selection and active object
-        for obj in bpy.context.selected_objects:
-            obj.select = False
-
-        for obj in selected_objects:
-            obj.select = True
-
-        bpy.context.scene.objects.active = active_object
+        bpy.ops.object.select_all(action='DESELECT')
+        Version.set_active_object(active_object)
 
     @staticmethod
     def pre_compute(gltf):

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_map_emissive.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_map_emissive.py
@@ -24,12 +24,15 @@ import bpy
 from .gltf2_blender_texture import *
 from ..com.gltf2_blender_material_helpers import *
 
+# Version management
+from ..blender_version import Version
+
 class BlenderEmissiveMap():
 
     @staticmethod
     def create(gltf, material_idx):
         engine = bpy.context.scene.render.engine
-        if engine == 'CYCLES':
+        if engine == Version.ENGINE:
             BlenderEmissiveMap.create_cycles(gltf, material_idx)
         else:
             pass #TODO for internal / Eevee in future 2.8
@@ -44,12 +47,14 @@ class BlenderEmissiveMap():
         BlenderTextureInfo.create(gltf, pymaterial.emissive_texture.index)
 
         # retrieve principled node and output node
-        principled = get_preoutput_node_output(node_tree)
+        principled = get_preoutput_node(node_tree)
         output = [node for node in node_tree.nodes if node.type == 'OUTPUT_MATERIAL'][0]
 
         # add nodes
         emit = node_tree.nodes.new('ShaderNodeEmission')
         emit.location = 0,1000
+        emit.inputs['Strength'].default_value = 1.0;
+
         if pymaterial.emissive_factor != [1.0,1.0,1.0]:
             separate = node_tree.nodes.new('ShaderNodeSeparateRGB')
             separate.location = -750, 1000
@@ -96,11 +101,6 @@ class BlenderEmissiveMap():
             node_tree.links.new(combine.inputs[0], math_R.outputs[0])
             node_tree.links.new(combine.inputs[1], math_G.outputs[0])
             node_tree.links.new(combine.inputs[2], math_B.outputs[0])
-            node_tree.links.new(emit.inputs[0], combine.outputs[0])
+            node_tree.links.new(principled.inputs[17], combine.outputs[0])
         else:
-            node_tree.links.new(emit.inputs[0], text.outputs[0])
-
-        # following  links will modify PBR node tree
-        node_tree.links.new(add.inputs[0], emit.outputs[0])
-        node_tree.links.new(add.inputs[1], principled)
-        node_tree.links.new(output.inputs[0], add.outputs[0])
+            node_tree.links.new(principled.inputs[17], text.outputs[0])

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_map_emissive.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_map_emissive.py
@@ -47,7 +47,7 @@ class BlenderEmissiveMap():
         BlenderTextureInfo.create(gltf, pymaterial.emissive_texture.index)
 
         # retrieve principled node and output node
-        principled = get_preoutput_node(node_tree)
+        preoutput = get_preoutput_node(node_tree)
         output = [node for node in node_tree.nodes if node.type == 'OUTPUT_MATERIAL'][0]
 
         # add nodes
@@ -93,6 +93,7 @@ class BlenderEmissiveMap():
         # create links
         node_tree.links.new(mapping.inputs[0], uvmap.outputs[0])
         node_tree.links.new(text.inputs[0], mapping.outputs[0])
+
         if pymaterial.emissive_factor != [1.0,1.0,1.0]:
             node_tree.links.new(separate.inputs[0], text.outputs[0])
             node_tree.links.new(math_R.inputs[0], separate.outputs[0])
@@ -101,6 +102,15 @@ class BlenderEmissiveMap():
             node_tree.links.new(combine.inputs[0], math_R.outputs[0])
             node_tree.links.new(combine.inputs[1], math_G.outputs[0])
             node_tree.links.new(combine.inputs[2], math_B.outputs[0])
-            node_tree.links.new(principled.inputs[17], combine.outputs[0])
+            #node_tree.links.new(principled.inputs[17], combine.outputs[0])
         else:
-            node_tree.links.new(principled.inputs[17], text.outputs[0])
+            pass#node_tree.links.new(principled.inputs[17], text.outputs[0])
+
+        # Create links for the emission part
+        if preoutput.type == "BSDF_PRINCIPLED":
+            node_tree.links.new( text.outputs["Color"], preoutput.inputs["Emission"] )
+        else:
+            node_tree.links.new( text.outputs["Color"],       emit.inputs["Color"] )
+            node_tree.links.new( emit.outputs["Emission"],    add.inputs[0] )
+            node_tree.links.new( preoutput.outputs["Shader"], add.inputs[1] )
+            node_tree.links.new( add.outputs["Shader"],       output.inputs["Surface"] )

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_map_normal.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_map_normal.py
@@ -23,12 +23,15 @@
 import bpy
 from .gltf2_blender_texture import *
 
+# Version management
+from ..blender_version import Version
+
 class BlenderNormalMap():
 
     @staticmethod
     def create(gltf, material_idx):
         engine = bpy.context.scene.render.engine
-        if engine == 'CYCLES':
+        if engine == Version.ENGINE:
             BlenderNormalMap.create_cycles(gltf, material_idx)
         else:
             pass #TODO for internal / Eevee in future 2.8
@@ -64,7 +67,7 @@ class BlenderNormalMap():
             uvmap["gltf2_texcoord"] = 0 #TODO set in pre_compute instead of here
 
         text  = BlenderTextureNode.create(gltf, pymaterial.normal_texture.index, node_tree, 'NORMALMAP')
-        text.color_space = 'NONE'
+        Version.set_colorspace(text)
         text.location = -500, -500
 
         normalmap_node = node_tree.nodes.new('ShaderNodeNormalMap')
@@ -82,7 +85,7 @@ class BlenderNormalMap():
 
         # following  links will modify PBR node tree
         if principled:
-            node_tree.links.new(principled.inputs[17], normalmap_node.outputs[0])
+            node_tree.links.new(principled.inputs[19], normalmap_node.outputs[0])
         if diffuse:
             node_tree.links.new(diffuse.inputs[2], normalmap_node.outputs[0])
         if glossy:

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_map_occlusion.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_map_occlusion.py
@@ -23,12 +23,15 @@
 import bpy
 from .gltf2_blender_texture import *
 
+# Version management
+from ..blender_version import Version
+
 class BlenderOcclusionMap():
 
     @staticmethod
     def create(gltf, material_idx):
         engine = bpy.context.scene.render.engine
-        if engine == 'CYCLES':
+        if engine == Version.ENGINE:
             BlenderOcclusionMap.create_cycles(gltf, material_idx)
         else:
             pass #TODO for internal / Eevee in future 2.8

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_material.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_material.py
@@ -81,6 +81,14 @@ class BlenderMaterial():
         material = bpy.data.materials[pymaterial.blender_material]
 
         node_tree = material.node_tree
+
+        #Fix alphas for 2.8
+        if bpy.app.version == (2, 80, 0):
+            if pymaterial.alpha_mode == 'BLEND':
+                material.blend_method = 'BLEND'
+            else:
+                material.blend_method = 'CLIP'
+
          # Add nodes for basic transparency
         # Add mix shader between output and Principled BSDF
         trans = node_tree.nodes.new('ShaderNodeBsdfTransparent')

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_mesh.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_mesh.py
@@ -93,11 +93,11 @@ class BlenderMesh():
 
         # Create basis shape key
         if max_shape_to_create > 0:
-            obj.shape_key_add("Basis")
+            obj.shape_key_add(name = "Basis")
 
         for i in range(max_shape_to_create):
 
-            obj.shape_key_add("target_" + str(i))
+            obj.shape_key_add(name="target_" + str(i))
 
             offset_idx = 0
             for prim in pymesh.primitives:
@@ -144,7 +144,7 @@ class BlenderMesh():
             if 'COLOR_0' in prim.attributes.keys():
                 # Create vertex color, once only per object
                 if vertex_color is None:
-                    vertex_color = obj.data.vertex_colors.new("COLOR_0")
+                    vertex_color = obj.data.vertex_colors.new(name="COLOR_0")
 
                 color_data = BinaryData.get_data_from_accessor(gltf, prim.attributes['COLOR_0'])
 
@@ -153,6 +153,9 @@ class BlenderMesh():
                         vert_idx = mesh.loops[loop_idx].vertex_index
                         if vert_idx in range(offset, offset + prim.vertices_length):
                             cpt_idx = vert_idx - offset
-                            vertex_color.data[loop_idx].color = color_data[cpt_idx][0:3]
-                            #TODO : no alpha in vertex color
+                            if bpy.app.version < (2, 80, 0):
+                                vertex_color.data[loop_idx].color = tuple(list(color_data[cpt_idx][0:3]))
+                            else:
+                                vertex_color.data[loop_idx].color = tuple(list(color_data[cpt_idx][0:3]) + [1.0])
+
             offset = offset + prim.vertices_length

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_node.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_node.py
@@ -26,6 +26,9 @@ from .gltf2_blender_camera import *
 from .gltf2_blender_skin import *
 from ..com.gltf2_blender_conversion import *
 
+# Version management
+from ..blender_version import Version
+
 class BlenderNode():
 
     @staticmethod
@@ -56,7 +59,11 @@ class BlenderNode():
 
             obj = bpy.data.objects.new(name, mesh)
             obj.rotation_mode = 'QUATERNION'
-            bpy.data.scenes[gltf.blender_scene].objects.link(obj)
+
+            if bpy.app.version == (2, 79, 0):
+                Version.link(gltf.blender_scene, obj)
+            else:
+                bpy.context.scene.collection.children[-1].objects.link(obj)
 
             # Transforms apply only if this mesh is not skinned
             # See implementation node of gltf2 specification
@@ -113,7 +120,13 @@ class BlenderNode():
             gltf.log.info("Blender create Empty node")
             obj = bpy.data.objects.new("Node", None)
         obj.rotation_mode = 'QUATERNION'
-        bpy.data.scenes[gltf.blender_scene].objects.link(obj)
+
+        if bpy.app.version == (2, 79, 0):
+            Version.link(gltf.blender_scene, obj)
+        else:
+            bpy.context.scene.collection.children[-1].objects.link(obj)
+
+
         BlenderNode.set_transforms(gltf, node_idx, pynode, obj, parent)
         pynode.blender_object = obj.name
         BlenderNode.set_parent(gltf, pynode, obj, parent)
@@ -133,27 +146,31 @@ class BlenderNode():
             if node_idx == parent:
                 if node.is_joint == True:
                     bpy.ops.object.select_all(action='DESELECT')
-                    bpy.data.objects[node.blender_armature_name].select = True
-                    bpy.context.scene.objects.active = bpy.data.objects[node.blender_armature_name]
+                    Version.select(bpy.data.objects[node.blender_armature_name])
+                    Version.set_active_object(bpy.data.objects[node.blender_armature_name])
                     bpy.ops.object.mode_set(mode='EDIT')
                     bpy.data.objects[node.blender_armature_name].data.edit_bones.active = bpy.data.objects[node.blender_armature_name].data.edit_bones[node.blender_bone_name]
                     bpy.ops.object.mode_set(mode='OBJECT')
                     bpy.ops.object.select_all(action='DESELECT')
-                    obj.select = True
-                    bpy.data.objects[node.blender_armature_name].select = True
-                    bpy.context.scene.objects.active = bpy.data.objects[node.blender_armature_name]
-                    bpy.context.scene.update()
+                    Version.select(obj)
+                    Version.select(bpy.data.objects[node.blender_armature_name])
+                    Version.set_active_object(bpy.data.objects[node.blender_armature_name])
+                    bpy.context.object.update_tag(refresh={'OBJECT', 'DATA', 'TIME'})
                     bpy.ops.object.parent_set(type='BONE_RELATIVE', keep_transform=True)
+
                     # From world transform to local (-armature transform -bone transform)
-                    bone_trans = bpy.data.objects[node.blender_armature_name].pose.bones[node.blender_bone_name].matrix.to_translation().copy()
-                    bone_rot = bpy.data.objects[node.blender_armature_name].pose.bones[node.blender_bone_name].matrix.to_quaternion().copy()
+                    #bone_trans = bpy.data.objects[node.blender_armature_name].pose.bones[node.blender_bone_name].matrix.to_translation().copy()
+                    #bone_rot = bpy.data.objects[node.blender_armature_name].pose.bones[node.blender_bone_name].matrix.to_quaternion().copy()
+                    bone_trans = node.blender_bone_matrix.to_translation().copy()
+                    bone_rot   = node.blender_bone_matrix.to_quaternion().copy()
+
                     bone_scale_mat = Conversion.scale_to_matrix(node.blender_bone_matrix.to_scale())
-                    obj.location = bone_scale_mat * obj.location
-                    obj.location = bone_rot * obj.location
+                    obj.location = Version.mat_mult(bone_scale_mat, obj.location)
+                    obj.location = Version.mat_mult(bone_rot, obj.location)
                     obj.location += bone_trans
-                    obj.location = bpy.data.objects[node.blender_armature_name].matrix_world.to_quaternion() * obj.location
-                    obj.rotation_quaternion = obj.rotation_quaternion * bpy.data.objects[node.blender_armature_name].matrix_world.to_quaternion()
-                    obj.scale = bone_scale_mat * obj.scale
+                    obj.location = Version.mat_mult(bpy.data.objects[node.blender_armature_name].matrix_world.to_quaternion(), obj.location)
+                    obj.rotation_quaternion = Version.mat_mult(obj.rotation_quaternion, bpy.data.objects[node.blender_armature_name].matrix_world.to_quaternion())
+                    obj.scale = Version.mat_mult(bone_scale_mat, obj.scale)
 
                     return
                 if node.blender_object:

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_pbrMetallicRoughness.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_pbrMetallicRoughness.py
@@ -23,11 +23,14 @@
 import bpy
 from .gltf2_blender_texture import *
 
+# Version management
+from ..blender_version import Version
+
 class BlenderPbr():
 
     def create(gltf, pypbr, mat_name, vertex_color):
         engine = bpy.context.scene.render.engine
-        if engine == 'CYCLES':
+        if engine == Version.ENGINE:
             BlenderPbr.create_cycles(gltf, pypbr, mat_name, vertex_color)
         else:
             pass #TODO for internal / Eevee in future 2.8
@@ -258,7 +261,7 @@ class BlenderPbr():
         elif pypbr.metallic_type == gltf.TEXTURE:
             BlenderTextureInfo.create(gltf, pypbr.metallic_roughness_texture.index)
             metallic_text = BlenderTextureNode.create(gltf, pypbr.metallic_roughness_texture.index, node_tree, 'METALLIC ROUGHNESS')
-            metallic_text.color_space = 'NONE'
+            Version.set_colorspace(metallic_text)
             metallic_text.location = -500,0
 
             metallic_separate = node_tree.nodes.new('ShaderNodeSeparateRGB')
@@ -286,7 +289,7 @@ class BlenderPbr():
 
             BlenderTextureInfo.create(gltf, pypbr.metallic_roughness_texture.index)
             metallic_text = BlenderTextureNode.create(gltf, pypbr.metallic_roughness_texture.index, node_tree, 'METALLIC ROUGHNESS')
-            metallic_text.color_space = 'NONE'
+            Version.set_colorspace(metallic_text)
             metallic_text.location = -1000,0
 
             metallic_separate = node_tree.nodes.new('ShaderNodeSeparateRGB')

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_primitive.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_primitive.py
@@ -89,8 +89,9 @@ class BlenderPrimitive():
 
     def set_UV(gltf, pyprimitive, obj, mesh, offset):
         for texcoord in [attr for attr in pyprimitive.attributes.keys() if attr[:9] == "TEXCOORD_"]:
-            if not texcoord in mesh.uv_textures:
-                mesh.uv_textures.new(texcoord)
+            _layer = mesh.uv_textures if bpy.app.version == (2,79,0) else mesh.uv_layers
+            if not texcoord in _layer:
+                _layer.new(name=texcoord)
                 pyprimitive.blender_texcoord[int(texcoord[9:])] = texcoord
 
             texcoord_data = BinaryData.get_data_from_accessor(gltf, pyprimitive.attributes[texcoord])

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_scene.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_scene.py
@@ -27,6 +27,9 @@ from .gltf2_blender_node import *
 from .gltf2_blender_skin import *
 from .gltf2_blender_animation import *
 
+# Version management
+from ..blender_version import Version
+
 class BlenderScene():
 
     @staticmethod
@@ -40,6 +43,13 @@ class BlenderScene():
         obj_rotation.rotation_mode = 'QUATERNION'
         obj_rotation.rotation_quaternion = Quaternion((sqrt(2)/2, sqrt(2)/2,0.0,0.0))
 
+        # Create collection and link it to scene.
+        # Assuming that py.context.scene.collection.children[-1] will always return this collection
+        if bpy.app.version == (2, 80, 0):
+            import_collection = bpy.data.collections.new(root_name if root_name else 'GLTF_Collection')
+            bpy.context.scene.collection.children.link(import_collection)
+            import_collection.objects.link(obj_rotation)
+
         # Create a new scene only if not already exists in .blend file
         # TODO : put in current scene instead ?
         if pyscene.name not in [scene.name for scene in bpy.data.scenes]:
@@ -47,14 +57,14 @@ class BlenderScene():
                 scene = bpy.data.scenes.new(pyscene.name)
             else:
                 scene = bpy.context.scene
-            scene.render.engine = "CYCLES"
+
+            scene.render.engine = Version.ENGINE
 
             gltf.blender_scene = scene.name
         else:
             gltf.blender_scene = pyscene.name
 
-        for selected in bpy.context.selected_objects:
-            selected.select = False
+        bpy.ops.object.select_all(action='DESELECT')
 
         for node_idx in pyscene.nodes:
             BlenderNode.create(gltf, node_idx, None) # None => No parent
@@ -81,20 +91,15 @@ class BlenderScene():
 
 
         # Parent root node to rotation object
-        bpy.data.scenes[gltf.blender_scene].objects.link(obj_rotation)
+        Version.link(gltf.blender_scene, obj_rotation)
+
         for node_idx in pyscene.nodes:
             bpy.data.objects[gltf.data.nodes[node_idx].blender_object].parent = obj_rotation
 
         # Place imported model on cursor
-        obj_rotation.location = bpy.context.scene.cursor_location
+        obj_rotation.location = bpy.context.scene.cursor_location if bpy.app.version == (2, 79, 0) else bpy.context.scene.cursor.location
 
         # Make object selected to allow to transform it directly after import
-        try:
-            for selected in bpy.context.selected_objects:
-                selected.select = False
-
-            bpy.context.scene.objects.active = obj_rotation
-            obj_rotation.select = True
-        except Exception as e:
-            print(e)
-            pass
+        bpy.ops.object.select_all(action='DESELECT')
+        for o in obj_rotation.children:
+            Version.select(o)

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_skin.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_skin.py
@@ -26,6 +26,8 @@ from mathutils import Vector, Matrix, Quaternion
 from ..com.gltf2_blender_conversion import *
 from ...io.imp.gltf2_io_binary import *
 
+from ..blender_version import Version
+
 class BlenderSkin():
 
     @staticmethod
@@ -38,9 +40,14 @@ class BlenderSkin():
         else:
             name = "Armature_" + str(skin_id)
 
-        armature = bpy.data.armatures.new(name)
-        obj = bpy.data.objects.new(name, armature)
-        bpy.data.scenes[gltf.blender_scene].objects.link(obj)
+        armature = bpy.data.armatures.new(name=name)
+        obj = bpy.data.objects.new(name=name, object_data=armature)
+
+        if bpy.app.version == (2, 79, 0):
+            Version.link(gltf.blender_scene, obj)
+        else:
+            bpy.context.scene.collection.children[-1].objects.link(obj)
+
         pyskin.blender_armature_name = obj.name
         if parent is not None:
             obj.parent = bpy.data.objects[gltf.data.nodes[parent].blender_object]
@@ -88,16 +95,16 @@ class BlenderSkin():
 
             # Get armature space location (bindpose + pose)
             # Then, remove original bind location from armspace location, and bind rotation
-            final_location = (bind_location.inverted() * parent_mat * Matrix.Translation(location)).to_translation()
-            obj.pose.bones[pynode.blender_bone_name].location = bind_rotation.inverted().to_matrix().to_4x4() * final_location
+            final_location = ( Version.mat_mult( Version.mat_mult(bind_location.inverted(), parent_mat), Matrix.Translation(location)) ).to_translation()
+            obj.pose.bones[pynode.blender_bone_name].location = Version.mat_mult(bind_rotation.inverted().to_matrix().to_4x4(), final_location)
 
             # Do the same for rotation
-            obj.pose.bones[pynode.blender_bone_name].rotation_quaternion = (bind_rotation.to_matrix().to_4x4().inverted() * parent_mat * rotation.to_matrix().to_4x4()).to_quaternion()
-            obj.pose.bones[pynode.blender_bone_name].scale = (bind_scale.inverted() * parent_mat * Conversion.scale_to_matrix(scale)).to_scale()
+            obj.pose.bones[pynode.blender_bone_name].rotation_quaternion = ( Version.mat_mult( Version.mat_mult(bind_rotation.to_matrix().to_4x4().inverted(), parent_mat), rotation.to_matrix().to_4x4()) ).to_quaternion()
+            obj.pose.bones[pynode.blender_bone_name].scale = ( Version.mat_mult( Version.mat_mult(bind_scale.inverted(),parent_mat), Conversion.scale_to_matrix(scale)) ).to_scale()
         else:
-            obj.pose.bones[pynode.blender_bone_name].location = bind_location.inverted() * location
-            obj.pose.bones[pynode.blender_bone_name].rotation_quaternion = bind_rotation.inverted() * rotation
-            obj.pose.bones[pynode.blender_bone_name].scale = bind_scale.inverted() * scale
+            obj.pose.bones[pynode.blender_bone_name].location = Version.mat_mult(bind_location.inverted(), location)
+            obj.pose.bones[pynode.blender_bone_name].rotation_quaternion = Version.mat_mult(bind_rotation.inverted(), rotation)
+            obj.pose.bones[pynode.blender_bone_name].scale = Version.mat_mult(bind_scale.inverted(), scale)
 
     @staticmethod
     def create_bone(gltf, skin_id, node_id, parent):
@@ -108,8 +115,8 @@ class BlenderSkin():
         scene = bpy.data.scenes[gltf.blender_scene]
         obj   = bpy.data.objects[pyskin.blender_armature_name]
 
-        bpy.context.screen.scene = scene
-        scene.objects.active = obj
+        Version.set_scene(scene)
+        Version.set_active_object(obj)
         bpy.ops.object.mode_set(mode="EDIT")
 
         if pynode.name:
@@ -117,7 +124,7 @@ class BlenderSkin():
         else:
             name = "Bone_" + str(node_id)
 
-        bone = obj.data.edit_bones.new(name)
+        bone = obj.data.edit_bones.new(name=name)
         pynode.blender_bone_name = bone.name
         pynode.blender_armature_name = pyskin.blender_armature_name
         bone.tail = Vector((0.0,1.0,0.0)) # Needed to keep bone alive
@@ -132,7 +139,7 @@ class BlenderSkin():
         for node_id in pyskin.node_ids:
             obj = bpy.data.objects[gltf.data.nodes[node_id].blender_object]
             for bone in pyskin.joints:
-                obj.vertex_groups.new(gltf.data.nodes[bone].blender_bone_name)
+                obj.vertex_groups.new(name=gltf.data.nodes[bone].blender_bone_name)
 
     @staticmethod
     def assign_vertex_groups(gltf, skin_id):
@@ -190,9 +197,9 @@ class BlenderSkin():
             obj = bpy.data.objects[node.blender_object]
 
             for obj_sel in bpy.context.scene.objects:
-                obj_sel.select = False
-            obj.select = True
-            bpy.context.scene.objects.active = obj
+                Version.deselect(obj_sel)
+            Version.select(obj)
+            Version.set_active_object(obj)
 
             #bpy.ops.object.parent_clear(type='CLEAR_KEEP_TRANSFORM')
             #obj.parent = bpy.data.objects[pyskin.blender_armature_name]

--- a/addons/io_sketchfab_plugin/sketchfab/__init__.py
+++ b/addons/io_sketchfab_plugin/sketchfab/__init__.py
@@ -25,14 +25,21 @@ import json
 import shutil
 import tempfile
 
+
 class Config:
 
     # sometimes the path in preferences is empty
     def get_temp_path():
-        if bpy.context.user_preferences.filepaths.temporary_directory:
-            return bpy.context.user_preferences.filepaths.temporary_directory
+        if bpy.app.version == (2, 79, 0):
+            if bpy.context.user_preferences.filepaths.temporary_directory:
+                return bpy.context.user_preferences.filepaths.temporary_directory
+            else:
+                return tempfile.mkdtemp()
         else:
-            return tempfile.mkdtemp()
+            if bpy.context.preferences.filepaths.temporary_directory:
+                return bpy.context.preferences.filepaths.temporary_directory
+            else:
+                return tempfile.mkdtemp()
 
     ADDON_NAME = 'io_sketchfab'
     GITHUB_REPOSITORY_URL = 'https://github.com/sketchfab/blender-plugin'

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,9 @@ then
   cd glTF-Blender-IO/
   git apply ../khronos-gltf.patch
   cp -r ./addons/io_scene_gltf2/io/ ../addons/io_sketchfab_plugin/io/
-  cd ../
+  cd ../addons/io_sketchfab_plugin/io/
+  sed -i 's/io_scene_gltf2.io/./g' ./*/*.py
+  cd ../../../
 else
   # Create the ZIP files for release
   mkdir -p releases


### PR DESCRIPTION
Updates the code into a single version, which is compatible with Blender 2.79 and Blender 2.8 (with warnings).
Also adds some minor fixes on the code (diffuse/specular material import, cleaner node hierarchy on import...).