### PR TITLE
Fixes permission error and "selection only" filter in 2.79

### DIFF
--- a/addons/io_sketchfab_plugin/__init__.py
+++ b/addons/io_sketchfab_plugin/__init__.py
@@ -76,7 +76,7 @@ bl_info = {
     'author': 'Sketchfab',
     'license': 'GPL',
     'deps': '',
-    'version': (1, 2, 1),
+    'version': (1, 2, 2),
     "blender": (2, 80, 0),
     'location': 'View3D > Tools > Sketchfab',
     'warning': '',

--- a/addons/io_sketchfab_plugin/blender/blender_version.py
+++ b/addons/io_sketchfab_plugin/blender/blender_version.py
@@ -26,7 +26,7 @@ class Version:
     # Visibility
     def get_visible(obj):
         if bpy.app.version < (2, 80, 0):
-            return obj.hide
+            return (not obj.hide)
         else:
             return obj.visible_get()
     def set_visible(obj, visible):

--- a/addons/io_sketchfab_plugin/sketchfab/__init__.py
+++ b/addons/io_sketchfab_plugin/sketchfab/__init__.py
@@ -235,7 +235,10 @@ class Utils:
         root.select_set(True)
 
 class Cache:
-    SKETCHFAB_CACHE_FILE = os.path.join(os.path.dirname(__file__), ".cache")
+    SKETCHFAB_CACHE_FILE = os.path.join(
+        bpy.utils.user_resource("SCRIPTS", "sketchfab_cache", create=True),
+        ".cache"
+    ) # Use a user path to avoid permission-related errors
 
     def read():
         if not os.path.exists(Cache.SKETCHFAB_CACHE_FILE):


### PR DESCRIPTION
Fixes:
* Potential login errors due to cache file being in a directory with administrative privileges
* Using "Selection only" in Blender 2.79 led to Error 13