### PR TITLE
Fixes 3.0 beta and 3.1 alpha compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To install the addon, just download the **sketchfab-x-y-z.zip** file attached to
 The addon should then be available in the 3D view:
 
 * Blender 2.79: under the tab 'Sketchfab' in the Tools panel (shortcut **T**).
-* Blender 2.80: under the tab 'Sketchfab' in the Properties panel (shortcut **N**).
+* Blender 2.80 to 3.1.0: under the tab 'Sketchfab' in the Properties panel (shortcut **N**).
 
 **⚠️ Note to Blender 2.79 OSX/Linux users:** The addon uses its own version of the SSL library. It is embedded within the plugin and should work correctly, but do not hesitate to [report an issue](#report-an-issue) if you encounter any issue related to SSL.
 
@@ -35,6 +35,11 @@ Your Sketchfab username should then be displayed upon successful login, and you 
 
 Please note that your login credentials are stored in a temporary file on your local machine (to automatically log you in when starting Blender). You can clear it by simply logging out of your Sketchfab account through the **Log Out** button.
 
+### Log in as a member of an Organization
+
+If you are a member of an organization, you can select the organization you belong to in the "Sketchfab for Teams" dropdown.
+
+Doing so will allow you to browse, import and export models from and to projects within your organization.
 
 ## Import a model from Sketchfab
 

--- a/addons/io_sketchfab_plugin/__init__.py
+++ b/addons/io_sketchfab_plugin/__init__.py
@@ -77,7 +77,7 @@ bl_info = {
     'author': 'Sketchfab',
     'license': 'APACHE2',
     'deps': '',
-    'version': (1, 4, 1),
+    'version': (1, 4, 2),
     "blender": (2, 80, 0),
     'location': 'View3D > Tools > Sketchfab',
     'warning': '',

--- a/addons/io_sketchfab_plugin/__init__.py
+++ b/addons/io_sketchfab_plugin/__init__.py
@@ -1223,7 +1223,7 @@ class SketchfabBrowse(View3DPanel, bpy.types.Panel):
         #result_label = 'Click below to see more results'
         #col.label(text=result_label, icon='INFO')
         try:
-            col.template_icon_view(bpy.context.window_manager, 'result_previews', show_labels=True, scale=5.)
+            col.template_icon_view(bpy.context.window_manager, 'result_previews', show_labels=True, scale=8)
         except Exception:
             print('ResultsPanel: Failed to display results')
             pass

--- a/addons/io_sketchfab_plugin/blender/com/gltf2_blender_math.py
+++ b/addons/io_sketchfab_plugin/blender/com/gltf2_blender_math.py
@@ -16,7 +16,7 @@ import typing
 import math
 from mathutils import Matrix, Vector, Quaternion, Euler
 
-from io_scene_gltf2.blender.com.gltf2_blender_data_path import get_target_property_name
+from .gltf2_blender_data_path import get_target_property_name
 
 
 def list_to_mathutils(values: typing.List[float], data_path: str) -> typing.Union[Vector, Quaternion, Euler]:

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_texture.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_blender_texture.py
@@ -16,8 +16,8 @@ import bpy
 
 from .gltf2_blender_image import BlenderImage
 from ..com.gltf2_blender_conversion import texture_transform_gltf_to_blender
-from io_scene_gltf2.io.com.gltf2_io import Sampler
-from io_scene_gltf2.io.com.gltf2_io_constants import TextureFilter, TextureWrap
+from ...io.com.gltf2_io import Sampler
+from ...io.com.gltf2_io_constants import TextureFilter, TextureWrap
 
 def texture(
     mh,

--- a/addons/io_sketchfab_plugin/blender/imp/gltf2_io_draco_compression_extension.py
+++ b/addons/io_sketchfab_plugin/blender/imp/gltf2_io_draco_compression_extension.py
@@ -14,10 +14,10 @@
 
 from ctypes import *
 
-from io_scene_gltf2.io.com.gltf2_io import BufferView
-from io_scene_gltf2.io.imp.gltf2_io_binary import BinaryData
+from ...io.com.gltf2_io import BufferView
+from ...io.imp.gltf2_io_binary import BinaryData
 from ...io.com.gltf2_io_debug import print_console
-from io_scene_gltf2.io.com.gltf2_io_draco_compression_extension import dll_path
+from ...io.com.gltf2_io_draco_compression_extension import dll_path
 
 
 def decode_primitive(gltf, prim):

--- a/addons/io_sketchfab_plugin/sketchfab/__init__.py
+++ b/addons/io_sketchfab_plugin/sketchfab/__init__.py
@@ -242,7 +242,7 @@ class Utils:
 
 class Cache:
     SKETCHFAB_CACHE_FILE = os.path.join(
-        bpy.utils.user_resource("SCRIPTS", "sketchfab_cache", create=True),
+        bpy.utils.user_resource("SCRIPTS", path="sketchfab_cache", create=True),
         ".cache"
     ) # Use a user path to avoid permission-related errors
 


### PR DESCRIPTION
This PR mainly fixes an API compatibility issue to make the plugin compatible with Blender 3.0.0 beta and 3.1.0 alpha.
It also fixes potential crashes with relative module imports.