### PR TITLE
Update __init__.py - Release Blender  4.0

### DIFF
--- a/addons/io_sketchfab_plugin/__init__.py
+++ b/addons/io_sketchfab_plugin/__init__.py
@@ -1184,7 +1184,7 @@ def run_async(func):
 
 
 def import_model(gltf_path, uid):
-    bpy.ops.wm.import_modal('INVOKE_DEFAULT', gltf_path=gltf_path, uid=uid)
+    bpy.ops.import_scene.gltf(filepath=gltf_path, files=[{"name":"scene.gltf", "name":"scene.gltf"}], loglevel=50)
 
 
 def build_search_request(query, pbr, animated, staffpick, face_count, category, sort_by):


### PR DESCRIPTION
bpy.ops.import_scene.gltf(filepath=gltf_path, files=[{"name":"scene.gltf", "name":"scene.gltf"}], loglevel=50)

the file was correctly downloaded into the windows temporary folder but the import function was not performed

I am not an expert programmer and the method applied may not be correct

I copied the performed import function for the gltf files and modified the variables

for blender 4.0.1 version it works