### PR TITLE
Automatically generate a model attribution file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ If this fits your usecase better, you can also select the "Import from url" opti
 
 <p align="center"><img style="max-width:100%" src="https://user-images.githubusercontent.com/52042414/158480653-568f6a91-bcd4-4009-b927-4d5ffc400658.png"></p>
 
+When importing publicly available models, a text file named **sf_attributions** will automatically be created inside Blender. The creator credits and license informations for the downloaded models will be appended to this file. It can be accessed in the **Text Editor** workspace.
+
+<p align="center"><img style="max-width:100%" src="https://dl.dropbox.com/scl/fi/wbj15y2wfekxof06r9v0a/Screenshot-2024-06-15-155042.png?rlkey=8pk0yk768znwu7pxc8yk7e0cv&st=17d46hjr&dl=0"></p>
+
 <br>
 
 ## Export a model to Sketchfab


### PR DESCRIPTION
Added a class called "SF_Attributions" to __init__.py. When downloading a model, if the model information is available publicly i.e. the model is public, a text file will automatically be generated which will contain the credits to the author and license information. The change was made to the SketchfabDownloadModel.execute() function. 

[**Here is a video demo.**](https://dl.dropbox.com/scl/fi/pkbbii14dbqvlkup32hgu/Auto_Attributions_Demo.mp4?rlkey=a430lu93ztqbd19ebps8l63d8&st=n6tedn4p&dl=0)

Preview:
![Screenshot 2024-06-15 112535](https://github.com/sketchfab/blender-plugin/assets/142584764/920aa9ef-8df2-4dfc-a3da-f05d15287397)